### PR TITLE
fix(chunks): Use const instead of let

### DIFF
--- a/f/chunks.js
+++ b/f/chunks.js
@@ -16,7 +16,7 @@
  */
 
 function chunks(arr, size) {
-  let output = [];
+  const output = [];
   for (let i = 0; i < arr.length; i += size) {
     output.push(arr.slice(i, i + size));
   }


### PR DESCRIPTION
In the `chunks` function, we could change the `let output = []` into `const output = []` as we just push values into it, and not changing its reference :)