### PR TITLE
Add browser version of flatten

### DIFF
--- a/f/flatten.js
+++ b/f/flatten.js
@@ -15,10 +15,7 @@
  * limitations under the License.
  */
 
-function flatten(arr) {
-  return Array.prototype.concat.apply([], arr);
-}
-
+// Already defined on arrays
 // Example:
-flatten([1, [2, 3], [[4]]]);
-// returns [1, 2, 3, [4]]
+[1, [2, 3], [[4]]].flat()
+// returns [1, 2, 3, 4]

--- a/f/flattenLazy.js
+++ b/f/flattenLazy.js
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-function* flatten(it) {
+function* flatten(it, depth=Infinity) {
   for (let v of it) {
-    if (v[Symbol.iterator])
-      yield* v;
+    if (v[Symbol.iterator] && depth > 0)
+      yield* flatten(v, depth - 1);
     else
       yield v;
   }
@@ -26,4 +26,4 @@ function* flatten(it) {
 
 // Example:
 flatten([1, [2, 3], [[4]]]);
-// returns [1, 2, 3, [4]]
+// returns [1, 2, 3, 4]

--- a/test/flatten.test.js
+++ b/test/flatten.test.js
@@ -15,6 +15,10 @@
  * limitations under the License.
  */
 
-it('removes one level or array nesting', function () {
-  expect(f([[1],[2,3],4,[[5,6]]])).to.deep.equal([1,2,3,4,[5,6]]);
+ it('removes one level of array nesting', function () {
+  expect(f([[1],[2,3],4,[[5,6]]], 1)).to.deep.equal([1,2,3,4,[5,6]]);
+});
+
+it('remove all levels of array nesting', function () {
+  expect(f([[1],[2,3],4,[[5,6]]])).to.deep.equal([1,2,3,4,5,6]);
 });


### PR DESCRIPTION
Flatten is available in the Browser as Array.prototype.flat().
This PR switches to that version and at the same time adds support for a depth parameter (because the browser one supports it), so it's now compatible with the underscore version.